### PR TITLE
Add system info skill using OS and sys modules

### DIFF
--- a/backend/skills/skills_manager.py
+++ b/backend/skills/skills_manager.py
@@ -50,6 +50,9 @@ class SkillsManager:
                 self._load_skill(file_path)
             except Exception as e:
                 logger.error(f"Failed to load skill {file_path.name}: {e}")
+
+        # Register built-in skills that do not come from files
+        self._register_system_info_skill()
     
     def _load_skill(self, file_path: Path) -> None:
         """Load a single skill module from file"""
@@ -237,11 +240,30 @@ class SkillsManager:
             
             logger.info(f"Successfully removed skill: {skill_name}")
             return True
-            
+
         except Exception as e:
             logger.error(f"Failed to remove skill {skill_name}: {e}")
             return False
-    
+
     def skill_exists(self, skill_name: str) -> bool:
         """Check if a skill exists"""
         return skill_name in self.loaded_skills
+
+    def _register_system_info_skill(self) -> None:
+        """Register a built-in skill exposing basic OS and Python info"""
+
+        def _system_info(_message: str) -> Dict[str, Any]:
+            return {
+                'success': True,
+                'skill_name': 'system_info',
+                'platform': sys.platform,
+                'cwd': os.getcwd(),
+                'python_version': sys.version,
+            }
+
+        self.loaded_skills['system_info'] = {
+            'module': None,
+            'path': 'builtin',
+            'name': 'system_info',
+            'run_function': _system_info,
+        }

--- a/test_system_info_skill.py
+++ b/test_system_info_skill.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+from backend.skills.skills_manager import SkillsManager
+
+
+def test_system_info_skill(tmp_path):
+    manager = SkillsManager(str(tmp_path))
+    result = manager.execute_skill_by_name("system_info", "hello")
+    assert result["success"] is True
+    assert result["platform"] == sys.platform
+    assert result["cwd"] == os.getcwd()
+    assert result["python_version"] == sys.version
+


### PR DESCRIPTION
## Summary
- register built-in `system_info` skill that reports OS and Python details
- cover system info skill with a regression test

## Testing
- `ruff check backend/skills/skills_manager.py test_system_info_skill.py`
- `pytest test_system_info_skill.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c02277d0a0832a812375f4d2bdb8c6