### PR TITLE
Refactor backend tests for pytest compatibility

### DIFF
--- a/test_backend.py
+++ b/test_backend.py
@@ -1,80 +1,36 @@
-#!/usr/bin/env python3
-"""
-Quick test script for the updated Dexter backend API
-"""
-import json
-import sys
 import os
+import pytest
 
-# Get the directory where this script is located
-script_dir = os.path.dirname(os.path.abspath(__file__))
-# Add backend to path
-backend_dir = os.path.join(script_dir, 'backend')
-sys.path.insert(0, backend_dir)
+from backend.dexter_brain.config import Config
+from backend.dexter_brain.collaboration import CollaborationManager
+from backend.dexter_brain.utils import get_config_path
 
-def test_config_loading():
-    """Test if the config can be loaded successfully"""
-    try:
-        from dexter_brain.config import Config
-        from dexter_brain.utils import get_config_path
-        config = Config.load(get_config_path())
-        print("✓ Config loaded successfully")
-        print(f"  Models configured: {list(config.models.keys())}")
-        return config
-    except Exception as e:
-        print(f"✗ Failed to load config: {e}")
-        return None
+
+@pytest.fixture(scope="module")
+def config():
+    """Load the Dexter configuration used in backend tests."""
+    return Config.load(get_config_path())
+
+
+def test_config_loading(config):
+    """Ensure configuration loads and contains model definitions."""
+    assert isinstance(config.models, dict)
+    assert config.models, "No models configured"
+
 
 def test_collaboration_manager(config):
-    """Test if CollaborationManager can be initialized"""
-    try:
-        from dexter_brain.collaboration import CollaborationManager
-        collab_mgr = CollaborationManager(config)
-        print("✓ CollaborationManager initialized successfully")
-        
-        # Test active sessions method
-        active_sessions = collab_mgr.get_active_sessions()
-        print(f"  Active sessions: {len(active_sessions)}")
-        return collab_mgr
-    except Exception as e:
-        print(f"✗ Failed to initialize CollaborationManager: {e}")
-        return None
+    """Verify CollaborationManager initializes and exposes session API."""
+    collab_mgr = CollaborationManager(config)
+    assert collab_mgr.get_active_sessions() == []
 
-def test_api_imports():
-    """Test if the main API module imports correctly"""
-    try:
-        from dexter_brain.utils import get_config_path
-        # Set required environment variables
-        os.environ.setdefault("DEXTER_CONFIG_FILE", get_config_path())
-        os.environ.setdefault("DEXTER_DOWNLOADS_DIR", "/tmp/dexter_downloads")
-        
-        # Create downloads directory
-        os.makedirs("/tmp/dexter_downloads", exist_ok=True)
-        
-        from main import app
-        print("✓ Main API module imported successfully")
-        return True
-    except Exception as e:
-        print(f"✗ Failed to import main API: {e}")
-        return False
 
-if __name__ == "__main__":
-    print("Testing Dexter backend updates...")
-    print("-" * 40)
-    
-    # Test config loading
-    config = test_config_loading()
-    if not config:
-        sys.exit(1)
-    
-    # Test collaboration manager
-    collab_mgr = test_collaboration_manager(config)
-    if not collab_mgr:
-        sys.exit(1)
-    
-    # Test API imports
-    if not test_api_imports():
-        sys.exit(1)
-    
-    print("-" * 40)
-    print("✓ All tests passed! Backend should be ready to run.")
+def test_api_imports(monkeypatch):
+    """Check that the FastAPI app can be imported with required env vars."""
+    downloads_dir = "/tmp/dexter_downloads"
+    os.makedirs(downloads_dir, exist_ok=True)
+    monkeypatch.setenv("DEXTER_CONFIG_FILE", get_config_path())
+    monkeypatch.setenv("DEXTER_DOWNLOADS_DIR", downloads_dir)
+
+    from backend.main import app
+    assert hasattr(app, "router")
+


### PR DESCRIPTION
## Summary
- replace script-style backend tests with pytest fixtures and assertions

## Testing
- `pytest`
- `pytest test_backend.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c03625cdb0832aba60f06ab8a99e41