### PR TITLE
Add knowledge graph and memory manager

### DIFF
--- a/backend/dexter_brain/__init__.py
+++ b/backend/dexter_brain/__init__.py
@@ -5,6 +5,8 @@ from .campaigns import CampaignManager
 from .collaboration import CollaborationManager
 from .config import Config
 from .db import BrainDB
+from .memory import MemoryManager
+from .knowledge_graph import KnowledgeGraph
 from .error_healer import ErrorHealer
 from .error_tracker import ErrorTracker, ErrorSeverity
 from .enhanced_skills import create_and_test_skill_with_healing, get_sandbox_health_status
@@ -16,6 +18,8 @@ __all__ = [
     'CollaborationManager',
     'Config',
     'BrainDB',
+    'MemoryManager',
+    'KnowledgeGraph',
     'ErrorHealer',
     'ErrorTracker',
     'ErrorSeverity',

--- a/backend/dexter_brain/knowledge_graph.py
+++ b/backend/dexter_brain/knowledge_graph.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+from typing import Any, Dict, List
+
+from .db import BrainDB
+
+
+class KnowledgeGraph:
+    """In-memory cache of the knowledge graph backed by BrainDB."""
+
+    def __init__(self, db: BrainDB):
+        self.db = db
+        self.nodes: Dict[int, Dict[str, Any]] = {}
+        self.edges: List[Dict[str, Any]] = []
+        self._load_from_db()
+
+    def _load_from_db(self) -> None:
+        for row in self.db.fetchall("SELECT * FROM knowledge_nodes"):
+            node = self.db._row_to_dict(row)
+            self.nodes[node['id']] = node
+        for row in self.db.fetchall("SELECT * FROM knowledge_edges"):
+            self.edges.append(self.db._row_to_dict(row))
+
+    def add_node(self, label: str, data: Dict[str, Any] | None = None,
+                 embedding: List[float] | None = None) -> Dict[str, Any]:
+        node_id = self.db.add_knowledge_node(label, data, embedding)
+        node = self.db.get_knowledge_node(node_id)
+        self.nodes[node_id] = node
+        return node
+
+    def add_edge(self, source_id: int, target_id: int, relation: str,
+                 weight: float = 1.0, metadata: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        edge_id = self.db.add_knowledge_edge(source_id, target_id, relation, weight, metadata)
+        row = self.db.fetchone("SELECT * FROM knowledge_edges WHERE id = ?", (edge_id,))
+        edge = self.db._row_to_dict(row)
+        self.edges.append(edge)
+        return edge
+
+    def get_node(self, node_id: int) -> Dict[str, Any] | None:
+        node = self.nodes.get(node_id)
+        if node is None:
+            node = self.db.get_knowledge_node(node_id)
+            if node:
+                self.nodes[node_id] = node
+        return node
+
+    def get_neighbors(self, node_id: int) -> List[Dict[str, Any]]:
+        neighbors = [e for e in self.edges if e['source_id'] == node_id or e['target_id'] == node_id]
+        if not neighbors:
+            neighbors = self.db.get_neighbors(node_id)
+            self.edges.extend(neighbors)
+        return neighbors

--- a/backend/dexter_brain/memory.py
+++ b/backend/dexter_brain/memory.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+from collections import deque
+from typing import Any, Dict, List, Optional
+
+from .db import BrainDB
+
+
+class MemoryManager:
+    """Runtime short-term memory backed by persistent BrainDB."""
+
+    def __init__(self, db: BrainDB, stm_capacity: int = 100):
+        self.db = db
+        self.stm_capacity = stm_capacity
+        self.stm = deque(maxlen=stm_capacity)
+        # Preload recent short-term memories into RAM
+        for mem in db.get_memories('stm', limit=stm_capacity):
+            self.stm.append(mem)
+
+    def remember(self, content: str, memory_type: str = 'stm',
+                 metadata: Dict[str, Any] | None = None,
+                 tags: List[str] | None = None,
+                 importance: float = 0.5) -> int:
+        """Store a memory and update RAM cache when appropriate."""
+        mem_id = self.db.add_memory(content, memory_type, metadata, tags, importance)
+        if memory_type == 'stm':
+            self.stm.append({
+                'id': mem_id,
+                'type': memory_type,
+                'content': content,
+                'metadata': metadata or {},
+                'tags': tags or [],
+                'importance': importance,
+            })
+        return mem_id
+
+    def recall(self, query: str, limit: int = 5) -> List[Dict[str, Any]]:
+        """Search memories for context."""
+        return self.db.search_memories(query, limit=limit)
+
+    def get_recent(self, limit: int = 5) -> List[Dict[str, Any]]:
+        """Return the most recent short-term memories in RAM."""
+        if limit <= 0:
+            return []
+        return list(self.stm)[-limit:]

--- a/test_brain_memory.py
+++ b/test_brain_memory.py
@@ -1,0 +1,26 @@
+from backend.dexter_brain.db import BrainDB
+from backend.dexter_brain.memory import MemoryManager
+from backend.dexter_brain.knowledge_graph import KnowledgeGraph
+
+
+def test_memory_manager_stm_and_recall():
+    db = BrainDB(":memory:")
+    mgr = MemoryManager(db, stm_capacity=2)
+    mgr.remember("alpha")
+    mgr.remember("beta")
+    mgr.remember("gamma")  # Should push out oldest due to capacity
+    recent = mgr.get_recent(2)
+    assert len(recent) == 2
+    assert recent[-1]["content"] == "gamma"
+    results = mgr.recall("beta")
+    assert any(r["content"] == "beta" for r in results)
+
+
+def test_knowledge_graph_nodes_and_edges():
+    db = BrainDB(":memory:")
+    kg = KnowledgeGraph(db)
+    n1 = kg.add_node("node1", {"type": "test"})
+    n2 = kg.add_node("node2")
+    edge = kg.add_edge(n1["id"], n2["id"], "related")
+    neighbors = kg.get_neighbors(n1["id"])
+    assert edge in neighbors


### PR DESCRIPTION
## Summary
- Introduce persistent knowledge graph tables and helpers in BrainDB
- Add RAM-backed MemoryManager and KnowledgeGraph utilities
- Provide LLM slot access to contextual memories during calls

## Testing
- `pytest` *(fails: ConnectionError and async not supported)*
- `pytest test_brain_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_68c039e41574832a9dae4d804598ccc0